### PR TITLE
add output channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ For more examples see the [examples folder](examples/)
 
 ## TODO
 
-- [ ] Add output channel if ending in func(ctx, T) R err
 - [ ] More docs
 - [ ] Better Readme
 - [ ] Benchmarks

--- a/examples/02-input-channel/main.go
+++ b/examples/02-input-channel/main.go
@@ -18,6 +18,7 @@ func main() {
 	// simple here.
 	close(inputChannel)
 
+	// Register the input channel
 	flo.NewBuilder(flo.WithInput(inputChannel)).
 		Add(exclaim).
 		Add(exclaim).

--- a/examples/06-output-channel/main.go
+++ b/examples/06-output-channel/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/codyoss/flo"
+)
+
+func main() {
+	inputChannel := make(chan string, 2)
+	inputChannel <- "Hello World"
+	inputChannel <- "Another message"
+	close(inputChannel)
+	// make an output channel to receive data from the flo
+	outputChannel := make(chan string, 1)
+
+	// Register the output channel
+	flo.NewBuilder(flo.WithInput(inputChannel), flo.WithOutput(outputChannel)).
+		Add(exclaim).
+		Add(exclaim).
+		BuildAndExecute(context.Background())
+
+	fmt.Println(<-outputChannel)
+	fmt.Println(<-outputChannel)
+	// It is your responsibility to close this channel once the flo shutsdown
+	close(outputChannel)
+	// Output:
+	// Hello World!!!
+	// Another message!!!
+}
+
+func exclaim(ctx context.Context, msg string) (string, error) {
+	return msg + "!", nil
+}


### PR DESCRIPTION
It may be useful to brige output of flo with other parts of the
codebase. For this reason the user of this lib may now register an
output channel with the flo. This will allow them to receive the output
of the final step.